### PR TITLE
Add make support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.elf
+*.bin
+.vscode

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -1,3 +1,4 @@
+#ifndef USE_MAKE
 //#define FD6288
 //#define TTRC4IN1              // or iflight target
 #define MP6531
@@ -5,6 +6,7 @@
 //#define tmotor45
 //#define hglrc
 //#define siskin
+#endif
 
 //GLOBAL
 //#define USE_ADC_INPUT

--- a/Src/main.c
+++ b/Src/main.c
@@ -44,7 +44,7 @@
  * -- removed onehot125 from crawler mode
  */
 
-
+#include <stdint.h>
 #include "main.h"
 
 #include "targets.h"

--- a/makefile
+++ b/makefile
@@ -43,4 +43,4 @@ $(TARGETS) :
 
 $(TARGETS:%=%.bin) : clean $(OBJ)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET).elf $(OBJ)
-	arm-none-eabi-objcopy -O binary $(TARGET).elf $(TARGET).bin
+	$(CP) $(TARGET).elf $(TARGET).bin

--- a/makefile
+++ b/makefile
@@ -1,0 +1,44 @@
+CC := arm-none-eabi-gcc
+CFLAGS :=  -std=gnu99 -g -O2 -Wall -mlittle-endian -mthumb -mthumb-interwork -mcpu=cortex-m0 \
+	-fsingle-precision-constant -Wdouble-promotion
+LDFLAGS := -TSTM32F051K6TX_FLASH.ld --specs=nosys.specs
+MAIN_SRC_DIR := Src
+SRC_DIR := Startup \
+	Src \
+	Drivers/STM32F0xx_HAL_Driver/Src
+SRC := $(foreach dir,$(SRC_DIR),$(wildcard $(dir)/*.[cs]))
+OBJ := $(SRC:%.[cs]=%.o)
+INCLUDES := -IInc \
+	-IDrivers/STM32F0xx_HAL_Driver/Inc \
+	-IDrivers/CMSIS/Include \
+	-ICore/Inc \
+	-IDrivers/STM32F0xx_HAL_Driver/Inc/Legacy \
+	-IDrivers/CMSIS/Device/ST/STM32F0xx/Include
+VALUES := -DHSE_VALUE=8000000 \
+	-DSTM32F051x8 \
+	-DHSE_STARTUP_TIMEOUT=100 \
+	-DLSE_STARTUP_TIMEOUT=5000 \
+	-DLSE_VALUE=32768 \
+	-DDATA_CACHE_ENABLE=0 \
+	-DINSTRUCTION_CACHE_ENABLE=0 \
+	-DVDD_VALUE=3300 \
+	-DLSI_VALUE=40000 \
+	-DHSI_VALUE=8000000 \
+	-DUSE_FULL_LL_DRIVER \
+	-DPREFETCH_ENABLE=1 \
+	-DUSE_MAKE
+CFLAGS += $(INCLUDES) $(VALUES)
+CFLAGS += -D$(TARGET)
+TARGETS := FD6288 TTRC4IN1 MP6531 tmotor55 tmotor45 hglrc siskin
+
+.PHONY : clean all
+clean :
+	rm -f Src/*.o
+all : $(TARGETS)
+
+$(TARGETS) :
+	$(MAKE) TARGET=$@ $@.bin
+
+$(TARGETS:%=%.bin) : clean $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET).elf $(OBJ)
+	arm-none-eabi-objcopy -O binary $(TARGET).elf $(TARGET).bin

--- a/makefile
+++ b/makefile
@@ -1,20 +1,22 @@
 CC := arm-none-eabi-gcc
-CFLAGS :=  -std=gnu99 -g -O2 -Wall -mlittle-endian -mthumb -mthumb-interwork -mcpu=cortex-m0 \
-	-fsingle-precision-constant -Wdouble-promotion
-LDFLAGS := -TSTM32F051K6TX_FLASH.ld --specs=nosys.specs
+CP := arm-none-eabi-objcopy
+MCU := -mcpu=cortex-m0 -mthumb
+LDSCRIPT := STM32F051K6TX_FLASH.ld
+LIBS := -lc -lm -lnosys 
+LDFLAGS := $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections
 MAIN_SRC_DIR := Src
 SRC_DIR := Startup \
 	Src \
 	Drivers/STM32F0xx_HAL_Driver/Src
 SRC := $(foreach dir,$(SRC_DIR),$(wildcard $(dir)/*.[cs]))
 OBJ := $(SRC:%.[cs]=%.o)
-INCLUDES := -IInc \
+INCLUDES :=  \
+	-IInc \
 	-IDrivers/STM32F0xx_HAL_Driver/Inc \
 	-IDrivers/CMSIS/Include \
-	-ICore/Inc \
-	-IDrivers/STM32F0xx_HAL_Driver/Inc/Legacy \
-	-IDrivers/CMSIS/Device/ST/STM32F0xx/Include
-VALUES := -DHSE_VALUE=8000000 \
+	-IDrivers/CMSIS/Device/ST/STM32F0xx/Include 
+VALUES :=  \
+	-DHSE_VALUE=8000000 \
 	-DSTM32F051x8 \
 	-DHSE_STARTUP_TIMEOUT=100 \
 	-DLSE_STARTUP_TIMEOUT=5000 \
@@ -25,11 +27,11 @@ VALUES := -DHSE_VALUE=8000000 \
 	-DLSI_VALUE=40000 \
 	-DHSI_VALUE=8000000 \
 	-DUSE_FULL_LL_DRIVER \
-	-DPREFETCH_ENABLE=1 \
-	-DUSE_MAKE
-CFLAGS += $(INCLUDES) $(VALUES)
+	-DPREFETCH_ENABLE=1
+CFLAGS := $(MCU) $(VALUES) $(INCLUDES) -O2 -Wall -fdata-sections -ffunction-sections
+CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 CFLAGS += -D$(TARGET)
-TARGETS := FD6288 TTRC4IN1 MP6531 tmotor55 tmotor45 hglrc siskin
+TARGETS := FD6288 MP6531 IFLIGHT TMOTOR55 TMOTOR45 HGLRC
 
 .PHONY : clean all
 clean :


### PR DESCRIPTION
All F051 targets can build correctly and workable with bootloader v4. 

Some details are not very friendly for local build since this is prepared for CI.

I'll write a doc for using this toolchain this weekend.