### PR TITLE
Moved firmware name / version to a fixed location so that they can be queried in files / on chip.

### DIFF
--- a/STM32F051K6TX_FLASH.ld
+++ b/STM32F051K6TX_FLASH.ld
@@ -37,10 +37,12 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 
 MEMORY
 {
-  SRAM    (xrw)   : ORIGIN = 0x20000000,    LENGTH = 192
-  RAM     (xrw)   : ORIGIN = 0x200000C0,    LENGTH = 8K - 192
-FLASH (rx)      : ORIGIN = 0x8001000, LENGTH = 27K
-EEPROM (rx)     : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH) LENGTH = 1K
+  SRAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 192
+  RAM           (xrw) : ORIGIN = 0x200000C0, LENGTH = 8K - 192
+  FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
+  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 14
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 27K - (LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  EEPROM        (rx)  : ORIGIN = 0x080007C00, LENGTH = 1K
 }
 
 /* Sections */
@@ -52,7 +54,14 @@ SECTIONS
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >FLASH
+  } >FLASH_VECTAB
+
+  /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
+  .firmware_version :
+  {
+    . = ALIGN(4);
+	KEEP (*(.firmware_info))
+  } >FLASH_VERSION
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Src/main.c
+++ b/Src/main.c
@@ -59,10 +59,17 @@
 #include "functions.h"
 #include "peripherals.h"
 
-uint8_t version_major = 1;
-uint8_t version_minor = 60;
+typedef struct __attribute__((packed)) {
+  uint8_t version_major;
+  uint8_t version_minor;
+  char device_name[12];
+} firmware_info_s;
 
-uint8_t device_name[12] = FIRMWARE_NAME ;
+firmware_info_s __attribute__ ((section(".firmware_info"))) firmware_info = {
+  version_major: 1,
+  version_minor: 60,
+  device_name: FIRMWARE_NAME
+};
 
 #define APPLICATION_ADDRESS 0x08001000
 #define EEPROM_START_ADD  (uint32_t)0x08007C00
@@ -847,11 +854,11 @@ int main(void)
 
   loadEEpromSettings();
 
-  if(version_major != eepromBuffer[3] || version_minor != eepromBuffer[4]){
-	  eepromBuffer[3] = version_major;
-	  eepromBuffer[4] = version_minor;
+  if(firmware_info.version_major != eepromBuffer[3] || firmware_info.version_minor != eepromBuffer[4]){
+	  eepromBuffer[3] = firmware_info.version_major;
+	  eepromBuffer[4] = firmware_info.version_minor;
 	  for(int i = 0; i < 12 ; i ++){
-		  eepromBuffer[5+i] = device_name[i];
+		  eepromBuffer[5+i] = firmware_info.device_name[i];
 	  }
 	  saveEEpromSettings();
   }

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CP := arm-none-eabi-objcopy
 MCU := -mcpu=cortex-m0 -mthumb
 LDSCRIPT := STM32F051K6TX_FLASH.ld
 LIBS := -lc -lm -lnosys 
-LDFLAGS := -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections
+LDFLAGS := -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 MAIN_SRC_DIR := Src
 SRC_DIR := Startup \
 	Src \


### PR DESCRIPTION
Now the firmware version and name will appear at location 0x10C0 in all firmware versions:

```
mikeller@pc:~/git/AM32-MultiRotor-ESC-firmware$ hexdump -C IFLIGHT.bin | head -20
00000000  00 20 00 20 5d 14 00 08  e5 22 00 08 e9 22 00 08  |. . ]...."..."..|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 ed 22 00 08  |............."..|
00000030  00 00 00 00 00 00 00 00  f1 22 00 08 f5 22 00 08  |........."..."..|
00000040  ad 14 00 08 ad 14 00 08  ad 14 00 08 ad 14 00 08  |................|
*
00000060  ad 14 00 08 0d 24 00 08  f9 22 00 08 39 23 00 08  |.....$..."..9#..|
00000070  71 23 00 08 35 24 00 08  ad 14 00 08 ad 14 00 08  |q#..5$..........|
00000080  e9 23 00 08 8d 23 00 08  00 00 00 00 a9 23 00 08  |.#...#.......#..|
00000090  c5 23 00 08 bd 23 00 08  ad 14 00 08 ad 14 00 08  |.#...#..........|
000000a0  ad 14 00 08 ad 14 00 08  ad 14 00 08 c1 23 00 08  |.............#..|
000000b0  ad 14 00 08 00 00 00 00  ad 14 00 08 00 00 00 00  |................|
000000c0  01 3c 49 46 6c 69 67 68  74 5f 35 30 41 20 00 00  |.<IFlight_50A ..|
000000d0  10 b5 06 4c 23 78 00 2b  07 d1 05 4b 00 2b 02 d0  |...L#x.+...K.+..|
000000e0  04 48 00 e0 00 bf 01 23  23 70 10 bd c8 01 00 20  |.H.....##p..... |
000000f0  00 00 00 00 58 4e 00 08  04 4b 10 b5 00 2b 03 d0  |....XN...K...+..|
00000100  03 49 04 48 00 e0 00 bf  10 bd c0 46 00 00 00 00  |.I.H.......F....|
00000110  cc 01 00 20 58 4e 00 08  00 22 43 08 8b 42 74 d3  |... XN..."C..Bt.|
00000120  03 09 8b 42 5f d3 03 0a  8b 42 44 d3 03 0b 8b 42  |...B_....BD....B|
00000130  28 d3 03 0c 8b 42 0d d3  ff 22 09 02 12 ba 03 0c  |(....B..."......|
```