### PR TITLE
Add action workflow to check code and build firmware automaticlly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Build All Targets
         run: make all
 
-      - name: Upload Artifact
+      - name: Upload Bin Files
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.ARITIFACT_NAME}}-BIN
+          name: ${{ env.ARTIFACT_NAME }}-BIN
           path: obj/*.bin
       
       - name: Upload Hex Files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: AM32-Firmware
+name: Build AM32 F051 Firmware
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
@@ -47,11 +47,11 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: firmware-artifact
-          path: obj
+          name: ${{ env.ARITIFACT_NAME}}-BIN
+          path: obj/*.bin
       
       - name: Upload Hex Files
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}-HEX
           path: obj/*.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Upload Hex Files
         uses: actions/upload-artifact@v2
         with:
-          name: ${ARTIFACT_NAME}
+          name: ${{ env.ARTIFACT_NAME }}
           path: obj/*.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: AM32-Firmware
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: install arm sdk
+        run: make arm_sdk_install
+
+      - name: build all targets
+        run: make all
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: firmware-artifact
+          path: obj

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout code
+      - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: install arm sdk
+      - name: Setup Python
+        uses: action/setup-python@v1
+
+      - name: Install ARM SDK
         run: make arm_sdk_install
 
-      - name: build all targets
+      - name: Get GitHub Build Number (ENV)
+        id: get_buildno
+        run: echo "GITHUBBUILDNUMBER=${{ github.run_number }}" >> $GITHUB_ENV
+        continue-on-error: true
+
+      - name: Get Pull Request Number
+        id: get_pullno
+        run: echo "PULL_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/pull/')
+
+      - name: Make artifact name
+        id: make_artifactname
+        run: |
+          ARTIFACT_NAME="AM32-F051-${{ github.run_number }}"
+          echo "${ARTIFACT_NAME}"
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+
+      - name: Build All Targets
         run: make all
 
-      - name: upload artifact
+      - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: firmware-artifact
           path: obj
+      
+      - name: Upload Hex Files
+        uses: action/upload-artifact@v2
+        with:
+          name: ${ARTIFACT_NAME}
+          path: obj/*.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python
-        uses: action/setup-python@v1
+        uses: actions/setup-python@v1
 
       - name: Install ARM SDK
         run: make arm_sdk_install
@@ -51,7 +51,7 @@ jobs:
           path: obj
       
       - name: Upload Hex Files
-        uses: action/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: ${ARTIFACT_NAME}
           path: obj/*.hex


### PR DESCRIPTION
Use github action to build firmware.

Firmware-artifact contains all generated files.

AM32-F051-${RunNumber} contains only hex files, for blheli-configurator