### PR TITLE
Add AM32 identifier

### DIFF
--- a/f051makefile.mk
+++ b/f051makefile.mk
@@ -39,12 +39,13 @@ TARGETS := FD6288 MP6531 IFLIGHT TMOTOR55 TMOTOR45 HGLRC SISKIN DIATONE MAMBA_F4
 # Working directories
 ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+IDENTIFIER    := AM32
 VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
 VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
 
 FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
 
-TARGET_BASENAME = $(BIN_DIR)/$(TARGET)_$(FIRMWARE_VERSION)
+TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
 
 # Build tools, so we all share the same versions
 # import macros common to all supported build systems

--- a/g071makefile.mk
+++ b/g071makefile.mk
@@ -67,7 +67,7 @@ clean :
 $(TARGETS) :
 	$(MAKE) TARGET=$@ binary
 
-binary : AM32_$(TARGET_BASENAME).bin
+binary : $(TARGET_BASENAME).bin
 
 $(TARGET_BASENAME).bin : $(SRC)
 	mkdir -p $(dir $@)

--- a/g071makefile.mk
+++ b/g071makefile.mk
@@ -40,12 +40,13 @@ TARGETS := G072ESC G071ENABLE G071_OPEN_DRAIN G071_OPEN_DRAIN_B
 # Working directories
 ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+IDENTIFIER    := AM32
 VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
 VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
 
 FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
 
-TARGET_BASENAME = $(BIN_DIR)/$(TARGET)_$(FIRMWARE_VERSION)
+TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
 
 # Build tools, so we all share the same versions
 # import macros common to all supported build systems
@@ -66,7 +67,7 @@ clean :
 $(TARGETS) :
 	$(MAKE) TARGET=$@ binary
 
-binary : $(TARGET_BASENAME).bin
+binary : AM32_$(TARGET_BASENAME).bin
 
 $(TARGET_BASENAME).bin : $(SRC)
 	mkdir -p $(dir $@)

--- a/gd32makefile.mk
+++ b/gd32makefile.mk
@@ -64,7 +64,7 @@ clean :
 $(TARGETS) :
 	$(MAKE) TARGET=$@ binary
 
-binary : AM32_$(TARGET_BASENAME).bin
+binary : $(TARGET_BASENAME).bin
 
 $(TARGET_BASENAME).bin : $(SRC)
 	mkdir -p $(dir $@)

--- a/gd32makefile.mk
+++ b/gd32makefile.mk
@@ -37,12 +37,13 @@ TARGETS := GD32TEST
 # Working directories
 ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+IDENTIFIER    := AM32
 VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
 VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
 
 FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
 
-TARGET_BASENAME = $(BIN_DIR)/$(TARGET)_$(FIRMWARE_VERSION)
+TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
 
 # Build tools, so we all share the same versions
 # import macros common to all supported build systems
@@ -63,7 +64,7 @@ clean :
 $(TARGETS) :
 	$(MAKE) TARGET=$@ binary
 
-binary : $(TARGET_BASENAME).bin
+binary : AM32_$(TARGET_BASENAME).bin
 
 $(TARGET_BASENAME).bin : $(SRC)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
This should help end-users more clearly identify which firmware is being flashed, especially for those who can't distinguish AM32 and other firmware (e.g. BLHeli_32).