### PR TITLE
Makefiles updates for easy maintenance

### DIFF
--- a/Mcu/f350/Inc/targets.h
+++ b/Mcu/f350/Inc/targets.h
@@ -20,6 +20,9 @@
 #define SINE_DIVIDER 3
 
 
+#define     MILLIVOLT_PER_AMP           20
+#define     CURRENT_OFFSET              0
+
 
 
 #ifdef GD32TEST

--- a/Mcu/f350/Src/IO.c
+++ b/Mcu/f350/Src/IO.c
@@ -13,7 +13,7 @@
 
 char ic_timer_prescaler = 1;
 char output_timer_prescaler;
-int servorawinput;
+//int servorawinput;
 int buffersize = 32;
 int smallestnumber = 20000;
 uint32_t dma_buffer[64];

--- a/f051makefile.mk
+++ b/f051makefile.mk
@@ -1,23 +1,26 @@
-CC = $(ARM_SDK_PREFIX)gcc
-CP = $(ARM_SDK_PREFIX)objcopy
-MCU := -mcpu=cortex-m0 -mthumb
-LDSCRIPT := Mcu/f051/STM32F051K6TX_FLASH.ld
-LIBS := -lc -lm -lnosys
-LDFLAGS := -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
-MAIN_SRC_DIR := Src
-SRC_DIR := Mcu/f051/Startup \
-	Src \
-    Mcu/f051/Src \
-	Mcu/f051/Drivers/STM32F0xx_HAL_Driver/Src
-SRC := $(foreach dir,$(SRC_DIR),$(wildcard $(dir)/*.[cs]))
-INCLUDES :=  \
-	-IInc \
-	-IMcu/f051/Inc \
-	-IMcu/f051/Drivers/STM32F0xx_HAL_Driver/Inc \
-	-IMcu/f051/Drivers/CMSIS/Include \
-	-IMcu/f051/Drivers/CMSIS/Device/ST/STM32F0xx/Include
-VALUES :=  \
-	-DUSE_MAKE \
+
+TARGETS_F051 := \
+	FD6288 MP6531 IFLIGHT TMOTOR55 TMOTOR45 HGLRC SISKIN \
+	DIATONE MAMBA_F40PRO MAMBA_F50PRO MAMBA_F60PRO \
+	WRAITH32 CRTEENSY_HILARIESC
+
+HAL_FOLDER_F051 := $(HAL_FOLDER)/f051
+
+MCU_F051 := -mcpu=cortex-m0 -mthumb
+LDSCRIPT_F051 := $(HAL_FOLDER_F051)/STM32F051K6TX_FLASH.ld
+
+SRC_DIR_F051 += \
+	$(HAL_FOLDER_F051)/Startup \
+	$(HAL_FOLDER_F051)/Src \
+	$(HAL_FOLDER_F051)/Drivers/STM32F0xx_HAL_Driver/Src
+
+CFLAGS_F051 := \
+	-I$(HAL_FOLDER_F051)/Inc \
+	-I$(HAL_FOLDER_F051)/Drivers/STM32F0xx_HAL_Driver/Inc \
+	-I$(HAL_FOLDER_F051)/Drivers/CMSIS/Include \
+	-I$(HAL_FOLDER_F051)/Drivers/CMSIS/Device/ST/STM32F0xx/Include
+
+CFLAGS_F051 += \
 	-DHSE_VALUE=8000000 \
 	-DSTM32F051x8 \
 	-DHSE_STARTUP_TIMEOUT=100 \
@@ -30,63 +33,5 @@ VALUES :=  \
 	-DHSI_VALUE=8000000 \
 	-DUSE_FULL_LL_DRIVER \
 	-DPREFETCH_ENABLE=1
-CFLAGS = $(MCU) $(VALUES) $(INCLUDES) -O2 -Wall -fdata-sections -ffunction-sections
-CFLAGS += -D$(TARGET)
-CFLAGS += -MMD -MP -MF $(@:%.bin=%.d)
 
-TARGETS := FD6288 MP6531 IFLIGHT TMOTOR55 TMOTOR45 HGLRC SISKIN DIATONE MAMBA_F40PRO MAMBA_F50PRO MAMBA_F60PRO WRAITH32 CRTEENSY_HILARIESC
-
-# Working directories
-ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
-
-IDENTIFIER    := AM32
-VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
-VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
-
-FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
-
-TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
-
-# Build tools, so we all share the same versions
-# import macros common to all supported build systems
-include $(ROOT)/make/system-id.mk
-
-# configure some directories that are relative to wherever ROOT_DIR is located
-BIN_DIR := $(ROOT)/obj
-
-TOOLS_DIR ?= $(ROOT)/tools
-DL_DIR := $(ROOT)/downloads
-
-.PHONY : clean all
-all : $(TARGETS)
-
-clean :
-	rm -rf $(BIN_DIR)/*
-
-$(TARGETS) :
-	$(MAKE) TARGET=$@ binary
-
-binary : $(TARGET_BASENAME).bin
-
-$(TARGET_BASENAME).bin : $(SRC)
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET_BASENAME).elf $(SRC)
-	$(CP) -O binary $(TARGET_BASENAME).elf $(TARGET_BASENAME).bin
-	$(CP) $(TARGET_BASENAME).elf -O ihex  $(TARGET_BASENAME).hex
-
-# mkdirs
-$(DL_DIR):
-	mkdir -p $@
-
-$(TOOLS_DIR):
-	mkdir -p $@
-
-# include the tools makefile
-include $(ROOT)/make/tools.mk
-
-
-
-
-
-
-
+SRC_F051 := $(foreach dir,$(SRC_DIR_F051),$(wildcard $(dir)/*.[cs]))

--- a/g071makefile.mk
+++ b/g071makefile.mk
@@ -1,24 +1,24 @@
 
-CC = $(ARM_SDK_PREFIX)gcc
-CP = $(ARM_SDK_PREFIX)objcopy
-MCU := -mcpu=cortex-m0 -mthumb
-LDSCRIPT := Mcu/g071/STM32G071GBUX_FLASH.ld
-LIBS := -lc -lm -lnosys 
-LDFLAGS := -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
-MAIN_SRC_DIR := Src
-SRC_DIR := Mcu/g071/Startup \
-	Src \
-    Mcu/g071/Src \
-	Mcu/g071/Drivers/STM32G0xx_HAL_Driver/Src
-SRC := $(foreach dir,$(SRC_DIR),$(wildcard $(dir)/*.[cs]))
-INCLUDES :=  \
-	-IInc \
-	-IMcu/g071/Inc \
-	-IMcu/g071/Drivers/STM32G0xx_HAL_Driver/Inc \
-	-IMcu/g071/Drivers/CMSIS/Include \
-	-IMcu/g071/Drivers/CMSIS/Device/ST/STM32G0xx/Include 
-VALUES :=  \
-	-DUSE_MAKE \
+TARGETS_G071 := \
+	G072ESC G071ENABLE G071_OPEN_DRAIN G071_OPEN_DRAIN_B
+
+HAL_FOLDER_G071 := $(HAL_FOLDER)/g071
+
+MCU_G071 := -mcpu=cortex-m0 -mthumb
+LDSCRIPT_G071 := $(HAL_FOLDER_G071)/STM32G071GBUX_FLASH.ld
+
+SRC_DIR_G071 := \
+	$(HAL_FOLDER_G071)/Startup \
+	$(HAL_FOLDER_G071)/Src \
+	$(HAL_FOLDER_G071)/Drivers/STM32G0xx_HAL_Driver/Src
+
+CFLAGS_G071 := \
+	-I$(HAL_FOLDER_G071)/Inc \
+	-I$(HAL_FOLDER_G071)/Drivers/STM32G0xx_HAL_Driver/Inc \
+	-I$(HAL_FOLDER_G071)/Drivers/CMSIS/Include \
+	-I$(HAL_FOLDER_G071)/Drivers/CMSIS/Device/ST/STM32G0xx/Include
+
+CFLAGS_G071 += \
 	-DHSE_VALUE=8000000 \
 	-DSTM32G071xx \
 	-DHSE_STARTUP_TIMEOUT=100 \
@@ -31,56 +31,5 @@ VALUES :=  \
 	-DHSI_VALUE=16000000 \
 	-DUSE_FULL_LL_DRIVER \
 	-DPREFETCH_ENABLE=1
-CFLAGS = $(MCU) $(VALUES) $(INCLUDES) -O2 -Wall -fdata-sections -ffunction-sections
-CFLAGS += -D$(TARGET)
-CFLAGS += -MMD -MP -MF $(@:%.bin=%.d)
 
-TARGETS := G072ESC G071ENABLE G071_OPEN_DRAIN G071_OPEN_DRAIN_B
-
-# Working directories
-ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
-
-IDENTIFIER    := AM32
-VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
-VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
-
-FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
-
-TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
-
-# Build tools, so we all share the same versions
-# import macros common to all supported build systems
-include $(ROOT)/make/system-id.mk
-
-# configure some directories that are relative to wherever ROOT_DIR is located
-BIN_DIR := $(ROOT)/obj
-
-TOOLS_DIR ?= $(ROOT)/tools
-DL_DIR := $(ROOT)/downloads
-
-.PHONY : clean all
-all : $(TARGETS)
-
-clean :
-	rm -rf $(BIN_DIR)/*
-
-$(TARGETS) :
-	$(MAKE) TARGET=$@ binary
-
-binary : $(TARGET_BASENAME).bin
-
-$(TARGET_BASENAME).bin : $(SRC)
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET_BASENAME).elf $(SRC)
-	$(CP) -O binary $(TARGET_BASENAME).elf $(TARGET_BASENAME).bin
-	$(CP) $(TARGET_BASENAME).elf -O ihex  $(TARGET_BASENAME).hex
-
-# mkdirs
-$(DL_DIR):
-	mkdir -p $@
-
-$(TOOLS_DIR):
-	mkdir -p $@
-
-# include the tools makefile
-include $(ROOT)/make/tools.mk
+SRC_G071 := $(foreach dir,$(SRC_DIR_G071),$(wildcard $(dir)/*.[cs]))

--- a/gd32makefile.mk
+++ b/gd32makefile.mk
@@ -1,23 +1,24 @@
-CC = $(ARM_SDK_PREFIX)gcc
-CP = $(ARM_SDK_PREFIX)objcopy
-MCU := -mcpu=cortex-m4 -mthumb
-LDSCRIPT := Mcu/f350/STM32F302CBTX_FLASH.ld
-LIBS := -lc -lm -lnosys 
-LDFLAGS := -specs=nano.specs -T$(LDSCRIPT) $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
-MAIN_SRC_DIR := Src
-SRC_DIR := Mcu/f350/Startup \
-	Src \
-    Mcu/f350/Src \
-	Mcu/f350/Drivers/STM32F3xx_HAL_Driver/Src
-SRC := $(foreach dir,$(SRC_DIR),$(wildcard $(dir)/*.[cs]))
-INCLUDES :=  \
-	-IInc \
-	-IMcu/f350/Inc \
-	-IMcu/f350/Drivers/STM32F3xx_HAL_Driver/Inc \
-	-IMcu/f350/Drivers/CMSIS/Include \
-	-IMcu/f350/Drivers/CMSIS/Device/ST/STM32F3xx/Include 
-VALUES :=  \
-	-DUSE_MAKE \
+
+TARGETS_GD32 := \
+	GD32TEST
+
+HAL_FOLDER_GD32 := $(HAL_FOLDER)/f350
+
+MCU_GD32 := -mcpu=cortex-m4 -mthumb
+LDSCRIPT_GD32 := $(HAL_FOLDER_GD32)/STM32F302CBTX_FLASH.ld
+
+SRC_DIR_GD32 := \
+	$(HAL_FOLDER_GD32)/Startup \
+	$(HAL_FOLDER_GD32)/Src \
+	$(HAL_FOLDER_GD32)/Drivers/STM32F3xx_HAL_Driver/Src
+
+CFLAGS_GD32 += \
+	-I$(HAL_FOLDER_GD32)/Inc \
+	-I$(HAL_FOLDER_GD32)/Drivers/STM32F3xx_HAL_Driver/Inc \
+	-I$(HAL_FOLDER_GD32)/Drivers/CMSIS/Include \
+	-I$(HAL_FOLDER_GD32)/Drivers/CMSIS/Device/ST/STM32F3xx/Include
+
+CFLAGS_GD32 += \
 	-DHSE_VALUE=8000000 \
 	-DSTM32F302xC \
 	-DHSE_STARTUP_TIMEOUT=100 \
@@ -28,56 +29,5 @@ VALUES :=  \
 	-DHSI_VALUE=8000000 \
 	-DUSE_FULL_LL_DRIVER \
 	-DPREFETCH_ENABLE=1
-CFLAGS = $(MCU) $(VALUES) $(INCLUDES) -O2 -Wall -fdata-sections -ffunction-sections
-CFLAGS += -D$(TARGET)
-CFLAGS += -MMD -MP -MF $(@:%.bin=%.d)
 
-TARGETS := GD32TEST
-
-# Working directories
-ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
-
-IDENTIFIER    := AM32
-VERSION_MAJOR := $(shell grep " VERSION_MAJOR" Src/main.c | awk '{print $$3}' )
-VERSION_MINOR := $(shell grep " VERSION_MINOR" Src/main.c | awk '{print $$3}' )
-
-FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
-
-TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
-
-# Build tools, so we all share the same versions
-# import macros common to all supported build systems
-include $(ROOT)/make/system-id.mk
-
-# configure some directories that are relative to wherever ROOT_DIR is located
-BIN_DIR := $(ROOT)/obj
-
-TOOLS_DIR ?= $(ROOT)/tools
-DL_DIR := $(ROOT)/downloads
-
-.PHONY : clean all
-all : $(TARGETS)
-
-clean :
-	rm -rf $(BIN_DIR)/*
-
-$(TARGETS) :
-	$(MAKE) TARGET=$@ binary
-
-binary : $(TARGET_BASENAME).bin
-
-$(TARGET_BASENAME).bin : $(SRC)
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET_BASENAME).elf $(SRC)
-	$(CP) -O binary $(TARGET_BASENAME).elf $(TARGET_BASENAME).bin
-	$(CP) $(TARGET_BASENAME).elf -O ihex  $(TARGET_BASENAME).hex
-
-# mkdirs
-$(DL_DIR):
-	mkdir -p $@
-
-$(TOOLS_DIR):
-	mkdir -p $@
-
-# include the tools makefile
-include $(ROOT)/make/tools.mk
+SRC_GD32 := $(foreach dir,$(SRC_DIR_GD32),$(wildcard $(dir)/*.[cs]))

--- a/makefile
+++ b/makefile
@@ -1,10 +1,104 @@
+QUIET = @
+
+# tools
+CC = $(ARM_SDK_PREFIX)gcc
+CP = $(ARM_SDK_PREFIX)objcopy
+ECHO = echo
+
+# common variables
+IDENTIFIER := AM32
+
+# Folders
+HAL_FOLDER := Mcu
+MAIN_SRC_DIR := Src
+MAIN_INC_DIR := Inc
+
+SRC_DIRS_COMMON := $(MAIN_SRC_DIR)
+
+# Include processor specific makefiles
 include f051makefile.mk
+include g071makefile.mk
+include gd32makefile.mk
 
-#include g071makefile.mk
+# Default MCU type to F051
+MCU_TYPE ?= F051
 
-#include gd32makefile.mk
+# additional libs
+LIBS := -lc -lm -lnosys
 
+# Compiler options
+CFLAGS_COMMON := -DUSE_MAKE
+CFLAGS_COMMON += -I$(MAIN_INC_DIR) -O2 -Wall -fdata-sections -ffunction-sections
+CFLAGS_COMMON += -D$(TARGET)
 
+# Linker options
+LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 
+# Working directories
+ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+# Search source files
+SRC_COMMON := $(foreach dir,$(SRC_DIRS_COMMON),$(wildcard $(dir)/*.[cs]))
 
+VERSION_MAJOR := $(shell grep " VERSION_MAJOR" $(MAIN_SRC_DIR)/main.c | awk '{print $$3}' )
+VERSION_MINOR := $(shell grep " VERSION_MINOR" $(MAIN_SRC_DIR)/main.c | awk '{print $$3}' )
+
+FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
+
+TARGET_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(TARGET)_$(FIRMWARE_VERSION)
+
+# Build tools, so we all share the same versions
+# import macros common to all supported build systems
+include $(ROOT)/make/system-id.mk
+
+# configure some directories that are relative to wherever ROOT_DIR is located
+BIN_DIR := $(ROOT)/obj
+
+TOOLS_DIR ?= $(ROOT)/tools
+DL_DIR := $(ROOT)/downloads
+
+.PHONY : clean all binary f051 g071 gd32
+all : $(TARGETS_F051) $(TARGETS_G071) $(TARGETS_GD32)
+f051 : $(TARGETS_F051)
+g071 : $(TARGETS_G071)
+gd32 : $(TARGETS_GD32)
+
+clean :
+	rm -rf $(BIN_DIR)/*
+
+binary : $(TARGET_BASENAME).bin
+	@$(ECHO) All done
+
+$(TARGETS_F051) :
+	@$(MAKE) -s MCU_TYPE=F051 TARGET=$@ binary
+
+$(TARGETS_G071) :
+	@$(MAKE) -s MCU_TYPE=G071 TARGET=$@ binary
+
+$(TARGETS_GD32) :
+	@$(MAKE) -s MCU_TYPE=GD32 TARGET=$@ binary
+
+# Compile target
+$(TARGET_BASENAME).elf: SRC := $(SRC_COMMON) $(SRC_$(MCU_TYPE))
+$(TARGET_BASENAME).elf: CFLAGS := $(MCU_F051) $(CFLAGS_$(MCU_TYPE)) $(CFLAGS_COMMON)
+$(TARGET_BASENAME).elf: LDFLAGS := $(LDFLAGS_COMMON) $(LDFLAGS_$(MCU_TYPE)) -T$(LDSCRIPT_$(MCU_TYPE))
+$(TARGET_BASENAME).elf: $(SRC)
+	@$(ECHO) Compiling $(notdir $@)
+	$(QUIET)mkdir -p $(dir $@)
+	$(QUIET)$(CC) $(CFLAGS) $(LDFLAGS) -MMD -MP -MF $(@:.elf=.d) -o $(@) $(SRC)
+
+# Generate bin and hex files
+$(TARGET_BASENAME).bin: $(TARGET_BASENAME).elf
+	@$(ECHO) Generating $(notdir $@)
+	$(QUIET)$(CP) -O binary $(<) $@
+	$(QUIET)$(CP) $(<) -O ihex $(@:.bin=.hex)
+
+# mkdirs
+$(DL_DIR):
+	$(QUIET)mkdir -p $@
+
+$(TOOLS_DIR):
+	$(QUIET)mkdir -p $@
+
+# include the tools makefile
+include $(ROOT)/make/tools.mk


### PR DESCRIPTION
Makefiles updated to allow build all targets without additional modifications.

Targets can be built independently using: 
* e.g. `make HGLRC` 

or per mcu type:
* `make f051`
* `make g071`
* `make gd32`

or all `make all`