### PR TITLE
Update the artifact name of the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Make artifact name
         id: make_artifactname
         run: |
-          ARTIFACT_NAME="AM32-F051-${{ github.run_number }}"
+          ARTIFACT_NAME="AM32-BUILD-${{ github.run_number }}"
           echo "${ARTIFACT_NAME}"
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
 


### PR DESCRIPTION
After https://github.com/AlkaMotors/AM32-MultiRotor-ESC-firmware/pull/63 we now have F051 and G071 built at the same time so the F051 name does not match up.